### PR TITLE
Grab contentBlocks from output of htmlToDraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ npm install html-to-draftjs --save
 import htmlToDraft from 'html-to-draftjs';
 
 const blocksFromHTML = htmlToDraft(this.props.content);
-const contentState = ContentState.createFromBlockArray(blocksFromHTML);
+const contentBlocks = blocksFromHtml.contentBlocks;
+const contentState = ContentState.createFromBlockArray(contentBlocks);
 const editorState = EditorState.createWithContent(contentState);
 ```


### PR DESCRIPTION
The example in the playground code was correct. Readme just missed a step grabbing the `contentBlocks` property.